### PR TITLE
ci: add release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
     branches:
       - main
   pull_request:
+
+env:
+  GOTOOLCHAIN: local
+
 jobs:
   build:
     name: test
@@ -12,5 +16,5 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v4
       with:
-        go-version: '1.21.0'
+        go-version: '1.22'
     - run: make

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,39 @@
+name: make
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+env:
+  GOTOOLCHAIN: local
+
+jobs:
+  release:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.22'
+
+      - run: make dist/sqlc-gen-python-orm.wasm.sha256
+
+      - run: |
+          SHA256=$(cat dist/sqlc-gen-python-orm.wasm.sha256)
+          URL="https://github.com/veltiosoft/sqlc-gen-python-orm/releases/download/${GITHUB_REF_NAME}/sqlc-gen-python-orm.wasm"
+  
+          echo '```' | tee -a release.md
+          echo "plugins:" | tee -a release.md
+          echo "- name: py" | tee -a release.md
+          echo "  wasm:" | tee -a release.md
+          echo "    url: ${URL}" | tee -a release.md
+          echo "    sha256: ${SHA256}" | tee -a release.md
+          echo '```' | tee -a release.md
+
+
+      - name: Upload Github Release
+        run: gh release create "${GITHUB_REF}" --notes-file release.md dist/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 dist
+.idea/
+.vscode/


### PR DESCRIPTION
example: https://github.com/trim21/sqlc-gen-python-orm/releases/tag/v0.0.12

you need tag new release as `v***` and ci will do the release.

Also generate a example easy to copy